### PR TITLE
fixing exchange declaration

### DIFF
--- a/lib/amqpx/publisher.ex
+++ b/lib/amqpx/publisher.ex
@@ -115,7 +115,7 @@ defmodule AMQPX.Publisher do
       type = Keyword.fetch!(exchange, :type)
       name = Keyword.fetch!(exchange, :name)
       opts = Keyword.fetch!(exchange, :options)
-      apply(AMQP.Exchange, type, [ch, name, opts])
+      AMQP.Exchange.declare(ch, name, type, opts)
     end)
 
     ch

--- a/lib/amqpx/receiver/standard.ex
+++ b/lib/amqpx/receiver/standard.ex
@@ -175,7 +175,7 @@ defmodule AMQPX.Receiver.Standard do
 
     case Keyword.pop(ex_opts, :declare) do
       {true, ex_opts} ->
-        :ok = apply(AMQP.Exchange, ex_type, [ch, ex_name, ex_opts])
+        :ok = AMQP.Exchange.declare(ch, ex_name, ex_type, ex_opts)
 
       _ ->
         nil

--- a/test/amqpx_test.exs
+++ b/test/amqpx_test.exs
@@ -110,6 +110,6 @@ defmodule AMQPX.Test do
 
     def handle([input], _meta), do: [input * 10]
 
-    def format_response(resp, _meta), do: {:json, resp}
+    def format_response(resp, _meta), do: {{:mime_type, :json}, resp}
   end
 end


### PR DESCRIPTION
           Exchange declaration is done with an apply on exchange type
           shortcut (i.e., AMQP.Exchange.topic(ch, exchange, opts).  The
           header exchange type does not have such a shortcut, so
           therefore toe apply is changed to a direct call to declare.

	   Also fixed test case for RPC