### PR TITLE
Receiver supervisor registered name

### DIFF
--- a/lib/amqpx/receiver.ex
+++ b/lib/amqpx/receiver.ex
@@ -53,6 +53,10 @@ defmodule AMQPX.Receiver do
   @impl Supervisor
   def init(args) do
     worker_args = Keyword.get(args, :worker, [])
+    case Keyword.get(args, :supervisor_name) do
+      nil -> :ok
+      name -> Process.register(self(), name)
+    end
 
     children = [
       {AMQPX.Watchdog, args},


### PR DESCRIPTION
Bet data pusher requires to randomly access children of a simple_one_for_one supervisor, this necessitates registered names for the AMQPX receiver process.